### PR TITLE
Change StateFlow<> to StateFlow<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ fun setNotes() {
 ### 3. Getting reactive immutable value updates
 
 To get immutable instance with reactive state updates, use method `asStateFlow()` which returns instance of
-[`StateFlow<>`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/-state-flow/).
+[`StateFlow<T>`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/-state-flow/).
 Whenever any field of Mutable model is updated with new value, this StateFlow gets updated with new immutable state value.
 
 ```kotlin


### PR DESCRIPTION
Change `StateFlow<>` to `StateFlow<T>` at README.md. This looks a bit more natural. And this is also the signature of the StateFlow interface.

And thanks for the good open source!
Please close this PR if intended.