### PR TITLE
[#9] Add support for atomic updates with Mutekt models

### DIFF
--- a/example/src/main/kotlin/dev/shreyaspatil/mutekt/example/Application.kt
+++ b/example/src/main/kotlin/dev/shreyaspatil/mutekt/example/Application.kt
@@ -68,18 +68,23 @@ class NotesViewModel(private val viewModelScope: CoroutineScope) {
 
             try {
                 val allNotes = getNotes()
-                _state.apply {
+                setState {
                     isLoading = false
                     notes = allNotes
                 }
             } catch (e: Throwable) {
-                _state.apply {
+                setState {
                     isLoading = false
                     error = e.message ?: "Error occurred"
                 }
             }
         }
     }
+
+    /**
+     * Mutates state atomically
+     */
+    private fun setState(mutate: MutableNotesState.() -> Unit) = _state.update(mutate)
 
     /**
      * Randomly either returns notes or fails with Exception.

--- a/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/ClassNames.kt
+++ b/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/ClassNames.kt
@@ -18,15 +18,17 @@ package dev.shreyaspatil.mutekt.codegen.codebuild
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
-import dev.shreyaspatil.mutekt.core.StateFlowable
+import dev.shreyaspatil.mutekt.core.AtomicExecutor
+import dev.shreyaspatil.mutekt.core.MutektMutableState
 
 object ClassNames {
 
-    fun stateFlowableOf(clazz: ClassName) = ClassName(
-        StateFlowable::class.java.packageName,
-        StateFlowable::class.simpleName!!
-    ).parameterizedBy(clazz)
+    fun mutektMutableState(
+        immutableInterface: ClassName,
+        mutableInterface: ClassName
+    ) = MutektMutableState::class.asClassName().parameterizedBy(immutableInterface, mutableInterface)
 
     fun stateFlowOf(clazz: ClassName) = ClassName(
         "kotlinx.coroutines.flow",
@@ -47,4 +49,6 @@ object ClassNames {
         "kotlinx.coroutines.flow",
         "FlowCollector"
     ).parameterizedBy(clazz)
+
+    fun atomicExecutor() = AtomicExecutor::class.asClassName()
 }

--- a/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/MemberNames.kt
+++ b/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/MemberNames.kt
@@ -21,4 +21,5 @@ object MemberNames {
     val COROUTINE_SCOPE = MemberName("kotlinx.coroutines", "coroutineScope")
     val COMBINE = MemberName("kotlinx.coroutines.flow", "combine")
     val STATE_IN = MemberName("kotlinx.coroutines.flow", "stateIn")
+    val FILTER_NOT_NULL = MemberName("kotlinx.coroutines.flow", "filterNotNull")
 }

--- a/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/mutableModel/MutableInterfaceModelBuilder.kt
+++ b/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/mutableModel/MutableInterfaceModelBuilder.kt
@@ -35,7 +35,7 @@ class MutableInterfaceModelBuilder(
 
     fun build() = TypeSpec.interfaceBuilder(interfaceName)
         .addSuperinterface(immutableStateInterface)
-        .addSuperinterface(ClassNames.stateFlowableOf(immutableStateInterface))
+        .addSuperinterface(ClassNames.mutektMutableState(immutableStateInterface, thisClass()))
         .addKdoc("Mutable state model for [%L]", immutableStateInterface.simpleName)
         .addMutableStateModelFields()
         .build()
@@ -43,4 +43,6 @@ class MutableInterfaceModelBuilder(
     private fun TypeSpec.Builder.addMutableStateModelFields() = apply {
         publicProperties.eachToProperty { mutable().addModifiers(KModifier.OVERRIDE) }.forEach { addProperty(it) }
     }
+
+    private fun thisClass() = ClassName(immutableStateInterface.packageName, interfaceName)
 }

--- a/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/mutableModel/impl/MutableClassModelImplBuilder.kt
+++ b/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/mutableModel/impl/MutableClassModelImplBuilder.kt
@@ -19,9 +19,12 @@ import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.NOTHING
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.buildCodeBlock
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.withIndent
@@ -44,9 +47,11 @@ class MutableClassModelImplBuilder(
         .addModifiers(KModifier.PRIVATE)
         .addSuperinterface(mutableModelInterfaceName)
         .primaryConstructor()
+        .privateAtomicExecutor()
         .addPrivateStateFlowAndGetterSetterFields()
         .immutableStateFlowImpl()
         .overrideFunAsStateFlow()
+        .overrideFunUpdate()
         .build()
 
     private fun TypeSpec.Builder.primaryConstructor() = apply {
@@ -54,6 +59,15 @@ class MutableClassModelImplBuilder(
             FunSpec
                 .constructorBuilder()
                 .addParameters(publicProperties.eachToParameter().toList())
+                .build()
+        )
+    }
+
+    private fun TypeSpec.Builder.privateAtomicExecutor() = apply {
+        addProperty(
+            PropertySpec.builder("_atomicExecutor", ClassNames.atomicExecutor())
+                .initializer("%T()", ClassNames.atomicExecutor())
+                .addModifiers(KModifier.PRIVATE)
                 .build()
         )
     }
@@ -117,6 +131,24 @@ class MutableClassModelImplBuilder(
                 .addModifiers(KModifier.OVERRIDE)
                 .returns(ClassNames.stateFlowOf(immutableStateInterface))
                 .addStatement("return _immutableStateFlowImpl")
+                .build()
+        )
+    }
+
+    private fun TypeSpec.Builder.overrideFunUpdate() = apply {
+        addFunction(
+            FunSpec.builder("update")
+                .addModifiers(KModifier.OVERRIDE)
+                .addParameter(
+                    ParameterSpec.builder(
+                        name = "mutate",
+                        type = LambdaTypeName.get(
+                            receiver = mutableModelInterfaceName,
+                            returnType = Unit::class.asClassName()
+                        )
+                    ).build()
+                )
+                .addStatement("_atomicExecutor.execute { mutate() }")
                 .build()
         )
     }
@@ -191,27 +223,24 @@ class StateFlowImplBuilder(
                         beginControlFlow("%M", MemberNames.COROUTINE_SCOPE)
                         withIndent {
                             beginControlFlow(
-                                "%M(%L) { params ->",
+                                "%M(_atomicExecutor.executing, %L) { params ->",
                                 MemberNames.COMBINE,
                                 publicProperties.joinToString { "_${it.simpleName.asString()}" }
                             )
 
                             withIndent {
-                                addStatement("Immutable%L(", type.simpleName)
+                                addStatement("val isUpdating = params[0] as Boolean")
 
-                                withIndent {
-                                    publicProperties.forEachIndexed { index, field ->
-                                        addStatement(
-                                            "%L = params[%L] as %L,",
-                                            field.simpleName.asString(),
-                                            index,
-                                            field.type.toTypeName()
-                                        )
-                                    }
-                                }
-                                addStatement(")")
+                                beginControlFlow("if (!isUpdating)")
+                                addStatement("value")
+                                endControlFlow()
+
+                                beginControlFlow("else")
+                                addStatement("null")
+                                endControlFlow()
                             }
                             endControlFlow()
+                            addStatement(".%M()", MemberNames.FILTER_NOT_NULL)
                             addStatement(".%M(this)", MemberNames.STATE_IN)
                             addStatement(".collect(collector)")
                         }

--- a/mutekt-core/src/main/kotlin/dev/shreyaspatil/mutekt/core/AtomicExecutor.kt
+++ b/mutekt-core/src/main/kotlin/dev/shreyaspatil/mutekt/core/AtomicExecutor.kt
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2022 Shreyas Patil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.shreyaspatil.mutekt.core
 
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/mutekt-core/src/main/kotlin/dev/shreyaspatil/mutekt/core/AtomicExecutor.kt
+++ b/mutekt-core/src/main/kotlin/dev/shreyaspatil/mutekt/core/AtomicExecutor.kt
@@ -1,0 +1,30 @@
+package dev.shreyaspatil.mutekt.core
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Executor which executes operation atomically.
+ */
+class AtomicExecutor {
+    private val _executing = MutableStateFlow(false)
+    val executing = _executing.asStateFlow()
+
+    /**
+     * Executes the [block] atomically.
+     * If already any operation is executing, it'll wait till its completion.
+     */
+    fun execute(block: () -> Unit) {
+        while (true) {
+            if (_executing.compareAndSet(expect = false, update = true)) {
+                try {
+                    block()
+                } finally {
+                    _executing.update { false }
+                }
+                return
+            }
+        }
+    }
+}

--- a/mutekt-core/src/main/kotlin/dev/shreyaspatil/mutekt/core/MutektState.kt
+++ b/mutekt-core/src/main/kotlin/dev/shreyaspatil/mutekt/core/MutektState.kt
@@ -30,7 +30,7 @@ interface MutektState<STATE> {
  * @property STATE Immutable State model type
  * @property MUTABLE_STATE Mutable State model type
  */
-interface MutektMutableState<STATE, MUTABLE_STATE: STATE> : MutektState<STATE> {
+interface MutektMutableState<STATE, MUTABLE_STATE : STATE> : MutektState<STATE> {
     /**
      * Updates the [MUTABLE_STATE].
      *

--- a/mutekt-core/src/main/kotlin/dev/shreyaspatil/mutekt/core/MutektState.kt
+++ b/mutekt-core/src/main/kotlin/dev/shreyaspatil/mutekt/core/MutektState.kt
@@ -18,8 +18,23 @@ package dev.shreyaspatil.mutekt.core
 import kotlinx.coroutines.flow.StateFlow
 
 /**
- * Promises that the implementor provides [StateFlow] of type [T]
+ * Represents the state model of type [STATE].
  */
-interface StateFlowable<T> {
-    fun asStateFlow(): StateFlow<T>
+interface MutektState<STATE> {
+    fun asStateFlow(): StateFlow<STATE>
+}
+
+/**
+ * Represents mutable state.
+ *
+ * @property STATE Immutable State model type
+ * @property MUTABLE_STATE Mutable State model type
+ */
+interface MutektMutableState<STATE, MUTABLE_STATE: STATE> : MutektState<STATE> {
+    /**
+     * Updates the [MUTABLE_STATE].
+     *
+     * @param mutate A lambda block which allows to perform mutation on [MUTABLE_STATE].
+     */
+    fun update(mutate: MUTABLE_STATE.() -> Unit)
 }

--- a/mutekt-core/src/test/kotlin/dev/shreyaspatil/mutekt/core/AtomicExecutorTest.kt
+++ b/mutekt-core/src/test/kotlin/dev/shreyaspatil/mutekt/core/AtomicExecutorTest.kt
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2022 Shreyas Patil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.shreyaspatil.mutekt.core
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class AtomicExecutorTest {
+    private lateinit var executor: AtomicExecutor
+
+    @BeforeEach
+    fun setUp() {
+        executor = AtomicExecutor()
+    }
+
+    @Test
+    fun test_execute() = runBlocking {
+        // Given: A sample variable to hold a value
+        var counter = 0
+
+        // When: Multiple jobs to be executed in AtomicExecutor
+        withContext(Dispatchers.Default) { // Executing this in Default dispatcher for parallelism
+            repeat(100) {
+                launch {
+                    repeat(1000) {
+                        executor.execute { counter++ }
+                    }
+                }
+            }
+        }
+
+        // Then: Count should be equal to 4
+        assertEquals(100000, counter)
+    }
+
+    @Test
+    fun test_executing() = runBlocking {
+        // Given: A lock for holding execution in executor
+        val mutex = Mutex(locked = true)
+
+        // When: Executor is executing task
+        val job = launch {
+            executor.execute {
+                runBlocking { mutex.lock() }
+            }
+        }
+        // Wait for executor to execute job
+        yield()
+
+        // Then: While task is being executed, state should be true
+        assertTrue(executor.executing.value)
+
+        // Then: On task finish (unlocking lock), state should be false
+        mutex.unlock()
+        job.join()
+        assertFalse(executor.executing.value)
+    }
+}

--- a/mutekt-core/src/test/kotlin/dev/shreyaspatil/mutekt/core/AtomicExecutorTest.kt
+++ b/mutekt-core/src/test/kotlin/dev/shreyaspatil/mutekt/core/AtomicExecutorTest.kt
@@ -51,7 +51,7 @@ class AtomicExecutorTest {
             }
         }
 
-        // Then: Count should be equal to 4
+        // Then: Count should be equal to number of executions
         assertEquals(100000, counter)
     }
 


### PR DESCRIPTION
# Summary

- Added support for atomic updates for multiple state fields of a Mutekt model.
Fixes: #9 
As discussed: #12 

For example: If the following is a model

```kt
@GenerateMutableModel
interface NotesState {
  val loading: Boolean
  val notes: List<String>
  val error: String?
}
```

Then, atomic update will be possible with `update{}` method:
```kt
val notesState = MutableNotesState(...)

notesState.update {
  loading = false
  notes = listOf("Lorem Ipsum")
}
```

Here, on mutating `loading` and `notes` field of a state, only a a single value will be emitted as a state without affecting the current coroutine dispatcher.

- Added interfaces `MutektState` and `MutektMutableState`. Mutable model implements it.
