### PR TITLE
Release v1.0.0-alpha03

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,3 +21,12 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: build --stacktrace
+
+      - name: Upload Coverage report to CodeCov
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: build/coverageReport/coverage.xml
+          flags: unittests
+          fail_ci_if_error: true
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -126,8 +126,7 @@ _You can find the latest version and changelogs in the [releases](https://github
 
 #### 1.3 Include generated classes in sources
 
-> **Note**   
-> In order to make IDE aware of generated code, it's important to include KSP generated sources in the project source sets.
+In order to make IDE aware of generated code, it's important to include KSP generated sources in the project source sets.
 
 Include generated sources as follows:
 

--- a/README.md
+++ b/README.md
@@ -61,12 +61,15 @@ fun setLoading() {
 }
 
 fun setNotes() {
-    _state.apply {
+    _state.update {
         isLoading = false
         notes = listOf("Lorem Ipsum")
     }
 }
 ```
+
+> **Note**  
+> Use method `update{}` on Mutable model instance to mutate multiple fields atomically. 
 
 ### 3. Getting reactive immutable value updates
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
     <a href="https://github.com/PatilShreyas/mutekt/actions/workflows/release.yml"><img src="https://github.com/PatilShreyas/mutekt/actions/workflows/release.yml/badge.svg"/></a>
     <a href="https://search.maven.org/search?q=g:dev.shreyaspatil.mutekt"><img src="https://img.shields.io/maven-central/v/dev.shreyaspatil.mutekt/mutekt-codegen?label=Maven%20Central&logo=android&style=flat-square"/></a>
     <a href="LICENSE"><img src="https://img.shields.io/github/license/PatilShreyas/mutekt?label=License)"/></a>
+    <a href="https://codecov.io/gh/PatilShreyas/mutekt"><img src="https://codecov.io/gh/PatilShreyas/mutekt/branch/main/graph/badge.svg?token=t5722h7jWn"/></a>
 </p>
 
 Generates mutable models from immutable model definitions. It's based on Kotlin's Symbol Processor (KSP).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     kotlin("jvm") version libs.versions.kotlin.asProvider().get() apply false
     alias(libs.plugins.spotless)
     alias(libs.plugins.mavenPublish) apply false
+    alias(libs.plugins.kotlin.kover)
 }
 
 repositories {
@@ -10,6 +11,7 @@ repositories {
 
 subprojects {
     apply(plugin = rootProject.libs.plugins.spotless.get().pluginId)
+    apply(plugin = rootProject.libs.plugins.kotlin.kover.get().pluginId)
     configure<com.diffplug.gradle.spotless.SpotlessExtension> {
         kotlin {
             target("**/*.kt")
@@ -18,5 +20,23 @@ subprojects {
             ktlint()
             licenseHeaderFile(rootProject.file("spotless/copyright.kt"))
         }
+    }
+}
+
+koverMerged {
+    enable()
+    filters {
+        projects {
+            excludes += listOf("example")
+        }
+    }
+    xmlReport {
+        onCheck.set(true)
+        reportFile.set(layout.buildDirectory.file("coverageReport/coverage.xml"))
+    }
+
+    htmlReport {
+        onCheck.set(true)
+        reportDir.set(layout.buildDirectory.dir("coverageReport/html"))
     }
 }

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     implementation(project(":mutekt-core"))
     ksp(project(":mutekt-codegen"))
 
-//     val mutektVersion = "1.0.0-alpha02"
+//     val mutektVersion = "1.0.0-alpha03"
 //     implementation("dev.shreyaspatil.mutekt:mutekt-core:$mutektVersion")
 //     ksp("dev.shreyaspatil.mutekt:mutekt-codegen:$mutektVersion")
 

--- a/example/src/main/kotlin/dev/shreyaspatil/mutekt/example/Application.kt
+++ b/example/src/main/kotlin/dev/shreyaspatil/mutekt/example/Application.kt
@@ -68,18 +68,23 @@ class NotesViewModel(private val viewModelScope: CoroutineScope) {
 
             try {
                 val allNotes = getNotes()
-                _state.apply {
+                setState {
                     isLoading = false
                     notes = allNotes
                 }
             } catch (e: Throwable) {
-                _state.apply {
+                setState {
                     isLoading = false
                     error = e.message ?: "Error occurred"
                 }
             }
         }
     }
+
+    /**
+     * Mutates state atomically
+     */
+    private fun setState(mutate: MutableNotesState.() -> Unit) = _state.update(mutate)
 
     /**
      * Randomly either returns notes or fails with Exception.

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ SONATYPE_HOST=DEFAULT
 RELEASE_SIGNING_ENABLED=true
 
 GROUP=dev.shreyaspatil.mutekt
-VERSION_NAME=1.0.0-alpha02
+VERSION_NAME=1.0.0-alpha03
 
 POM_INCEPTION_YEAR=2022
 POM_URL=https://github.com/PatilShreyas/mutekt/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,17 +7,23 @@ coroutine = "1.6.4"
 junitJupiter = "5.8.1"
 spotless = "6.9.0"
 mavenPublish = "0.21.0"
+kotlinCompileTesting = "1.4.9"
+kotlinKover = "0.6.0"
 
 [libraries]
 ksp-symbol-processing-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 kotlinPoet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlinPoet" }
 
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutine" }
+kotlinx-coroutines-testing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutine" }
 
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junitJupiter" }
+junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junitJupiter" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junitJupiter" }
+kotlin-compile-testing = { module = "com.github.tschuchortdev:kotlin-compile-testing-ksp", version.ref = "kotlinCompileTesting" }
 
 [plugins]
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
+kotlin-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kotlinKover" }

--- a/mutekt-codegen/build.gradle.kts
+++ b/mutekt-codegen/build.gradle.kts
@@ -14,7 +14,9 @@ dependencies {
     implementation(libs.kotlinPoet.ksp)
 
     testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.junit.jupiter.params)
     testRuntimeOnly(libs.junit.jupiter.engine)
+    testImplementation(libs.kotlin.compile.testing)
 }
 
 tasks.test {

--- a/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/ClassNames.kt
+++ b/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/ClassNames.kt
@@ -18,15 +18,17 @@ package dev.shreyaspatil.mutekt.codegen.codebuild
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
-import dev.shreyaspatil.mutekt.core.StateFlowable
+import dev.shreyaspatil.mutekt.core.AtomicExecutor
+import dev.shreyaspatil.mutekt.core.MutektMutableState
 
 object ClassNames {
 
-    fun stateFlowableOf(clazz: ClassName) = ClassName(
-        StateFlowable::class.java.packageName,
-        StateFlowable::class.simpleName!!
-    ).parameterizedBy(clazz)
+    fun mutektMutableState(
+        immutableInterface: ClassName,
+        mutableInterface: ClassName
+    ) = MutektMutableState::class.asClassName().parameterizedBy(immutableInterface, mutableInterface)
 
     fun stateFlowOf(clazz: ClassName) = ClassName(
         "kotlinx.coroutines.flow",
@@ -47,4 +49,6 @@ object ClassNames {
         "kotlinx.coroutines.flow",
         "FlowCollector"
     ).parameterizedBy(clazz)
+
+    fun atomicExecutor() = AtomicExecutor::class.asClassName()
 }

--- a/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/MemberNames.kt
+++ b/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/MemberNames.kt
@@ -21,4 +21,5 @@ object MemberNames {
     val COROUTINE_SCOPE = MemberName("kotlinx.coroutines", "coroutineScope")
     val COMBINE = MemberName("kotlinx.coroutines.flow", "combine")
     val STATE_IN = MemberName("kotlinx.coroutines.flow", "stateIn")
+    val FILTER_NOT_NULL = MemberName("kotlinx.coroutines.flow", "filterNotNull")
 }

--- a/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/ModelClassFileBuilder.kt
+++ b/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/ModelClassFileBuilder.kt
@@ -26,6 +26,9 @@ import dev.shreyaspatil.mutekt.codegen.codebuild.mutableModel.MutableInterfaceMo
 import dev.shreyaspatil.mutekt.codegen.codebuild.mutableModel.impl.MutableClassModelImplBuilder
 import dev.shreyaspatil.mutekt.codegen.codebuild.mutableModel.impl.MutableModelFactoryFunctionBuilder
 
+/**
+ * Builds a class containing required interfaces and implementations for Mutekt.
+ */
 class ModelClassFileBuilder(private val state: KSClassDeclaration) {
     private val packageName = state.packageName.asString()
     private val generatedClassFilename = "${state.simpleName.asString()}_Generated"

--- a/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/immutableModel/ImmutableDataClassModelBuilder.kt
+++ b/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/immutableModel/ImmutableDataClassModelBuilder.kt
@@ -28,6 +28,9 @@ import dev.shreyaspatil.mutekt.codegen.codebuild.ext.getPublicAbstractProperties
 
 /**
  * Generates private immutable data class for a state model.
+ *
+ * @property immutableStateInterface Immutable state interface class name
+ * @property publicProperties Public properties of interface
  */
 class ImmutableDataClassModelBuilder(
     private val immutableStateInterface: ClassName,

--- a/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/mutableModel/MutableInterfaceModelBuilder.kt
+++ b/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/mutableModel/MutableInterfaceModelBuilder.kt
@@ -35,7 +35,7 @@ class MutableInterfaceModelBuilder(
 
     fun build() = TypeSpec.interfaceBuilder(interfaceName)
         .addSuperinterface(immutableStateInterface)
-        .addSuperinterface(ClassNames.stateFlowableOf(immutableStateInterface))
+        .addSuperinterface(ClassNames.mutektMutableState(immutableStateInterface, thisClass()))
         .addKdoc("Mutable state model for [%L]", immutableStateInterface.simpleName)
         .addMutableStateModelFields()
         .build()
@@ -43,4 +43,6 @@ class MutableInterfaceModelBuilder(
     private fun TypeSpec.Builder.addMutableStateModelFields() = apply {
         publicProperties.eachToProperty { mutable().addModifiers(KModifier.OVERRIDE) }.forEach { addProperty(it) }
     }
+
+    private fun thisClass() = ClassName(immutableStateInterface.packageName, interfaceName)
 }

--- a/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/mutableModel/MutableInterfaceModelBuilder.kt
+++ b/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/mutableModel/MutableInterfaceModelBuilder.kt
@@ -25,6 +25,12 @@ import dev.shreyaspatil.mutekt.codegen.codebuild.ClassNames
 import dev.shreyaspatil.mutekt.codegen.codebuild.ext.eachToProperty
 import dev.shreyaspatil.mutekt.codegen.codebuild.ext.getPublicAbstractProperties
 
+/**
+ * Builds and generates interface definition of a mutable model
+ *
+ * @property immutableStateInterface Immutable state interface class name
+ * @property publicProperties Public properties of interface
+ */
 class MutableInterfaceModelBuilder(
     private val immutableStateInterface: ClassName,
     private val publicProperties: Sequence<KSPropertyDeclaration>

--- a/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/mutableModel/impl/MutableClassModelImplBuilder.kt
+++ b/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/mutableModel/impl/MutableClassModelImplBuilder.kt
@@ -34,6 +34,11 @@ import dev.shreyaspatil.mutekt.codegen.codebuild.ext.eachToParameter
 
 /**
  * Generates a mutable model class implementation
+ *
+ * @property immutableStateInterface Immutable state interface class name
+ * @property publicProperties Public properties of a state model interface
+ * @property mutableModelInterfaceName Mutable state interface class name
+ * @property immutableDataClassName Immutable data class name
  */
 class MutableClassModelImplBuilder(
     private val immutableStateInterface: ClassName,

--- a/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/mutableModel/impl/MutableClassModelImplBuilder.kt
+++ b/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/mutableModel/impl/MutableClassModelImplBuilder.kt
@@ -19,9 +19,12 @@ import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.NOTHING
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.buildCodeBlock
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.withIndent
@@ -44,9 +47,11 @@ class MutableClassModelImplBuilder(
         .addModifiers(KModifier.PRIVATE)
         .addSuperinterface(mutableModelInterfaceName)
         .primaryConstructor()
+        .privateAtomicExecutor()
         .addPrivateStateFlowAndGetterSetterFields()
         .immutableStateFlowImpl()
         .overrideFunAsStateFlow()
+        .overrideFunUpdate()
         .build()
 
     private fun TypeSpec.Builder.primaryConstructor() = apply {
@@ -54,6 +59,15 @@ class MutableClassModelImplBuilder(
             FunSpec
                 .constructorBuilder()
                 .addParameters(publicProperties.eachToParameter().toList())
+                .build()
+        )
+    }
+
+    private fun TypeSpec.Builder.privateAtomicExecutor() = apply {
+        addProperty(
+            PropertySpec.builder("_atomicExecutor", ClassNames.atomicExecutor())
+                .initializer("%T()", ClassNames.atomicExecutor())
+                .addModifiers(KModifier.PRIVATE)
                 .build()
         )
     }
@@ -117,6 +131,24 @@ class MutableClassModelImplBuilder(
                 .addModifiers(KModifier.OVERRIDE)
                 .returns(ClassNames.stateFlowOf(immutableStateInterface))
                 .addStatement("return _immutableStateFlowImpl")
+                .build()
+        )
+    }
+
+    private fun TypeSpec.Builder.overrideFunUpdate() = apply {
+        addFunction(
+            FunSpec.builder("update")
+                .addModifiers(KModifier.OVERRIDE)
+                .addParameter(
+                    ParameterSpec.builder(
+                        name = "mutate",
+                        type = LambdaTypeName.get(
+                            receiver = mutableModelInterfaceName,
+                            returnType = Unit::class.asClassName()
+                        )
+                    ).build()
+                )
+                .addStatement("_atomicExecutor.execute { mutate() }")
                 .build()
         )
     }
@@ -191,27 +223,24 @@ class StateFlowImplBuilder(
                         beginControlFlow("%M", MemberNames.COROUTINE_SCOPE)
                         withIndent {
                             beginControlFlow(
-                                "%M(%L) { params ->",
+                                "%M(_atomicExecutor.executing, %L) { params ->",
                                 MemberNames.COMBINE,
                                 publicProperties.joinToString { "_${it.simpleName.asString()}" }
                             )
 
                             withIndent {
-                                addStatement("Immutable%L(", type.simpleName)
+                                addStatement("val isUpdating = params[0] as Boolean")
 
-                                withIndent {
-                                    publicProperties.forEachIndexed { index, field ->
-                                        addStatement(
-                                            "%L = params[%L] as %L,",
-                                            field.simpleName.asString(),
-                                            index,
-                                            field.type.toTypeName()
-                                        )
-                                    }
-                                }
-                                addStatement(")")
+                                beginControlFlow("if (!isUpdating)")
+                                addStatement("value")
+                                endControlFlow()
+
+                                beginControlFlow("else")
+                                addStatement("null")
+                                endControlFlow()
                             }
                             endControlFlow()
+                            addStatement(".%M()", MemberNames.FILTER_NOT_NULL)
                             addStatement(".%M(this)", MemberNames.STATE_IN)
                             addStatement(".collect(collector)")
                         }

--- a/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/mutableModel/impl/MutableModelFactoryFunctionBuilder.kt
+++ b/mutekt-codegen/src/main/kotlin/dev/shreyaspatil/mutekt/codegen/codebuild/mutableModel/impl/MutableModelFactoryFunctionBuilder.kt
@@ -23,7 +23,11 @@ import com.squareup.kotlinpoet.KModifier
 import dev.shreyaspatil.mutekt.codegen.codebuild.ext.eachToParameter
 
 /**
- * Generates a top level function for creating instance of mutable model interface
+ * Generates a top level function for creating instance of mutable model interface.
+ *
+ * @property mutableInterfaceName Mutable state interface class name
+ * @property mutableImplClassName Mutable state interface's implementor class name
+ * @property publicProperties Public properties of a state model interface
  */
 class MutableModelFactoryFunctionBuilder(
     private val mutableInterfaceName: ClassName,

--- a/mutekt-codegen/src/test/kotlin/dev/shreyaspatil/mutekt/codegen/MutektCodegenProcessorTest.kt
+++ b/mutekt-codegen/src/test/kotlin/dev/shreyaspatil/mutekt/codegen/MutektCodegenProcessorTest.kt
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2022 Shreyas Patil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.shreyaspatil.mutekt.codegen
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.SourceFile.Companion.kotlin
+import com.tschuchort.compiletesting.kspWithCompilation
+import com.tschuchort.compiletesting.symbolProcessorProviders
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class MutektCodegenProcessorTest {
+
+    @TempDir
+    lateinit var temporaryFolder: Path
+
+    @Test
+    fun shouldCompile_whenModelIsValid() {
+        // Given
+        val source = """
+                    package dev.shreyaspatil.mutekt.example
+
+                    import dev.shreyaspatil.mutekt.core.annotations.GenerateMutableModel
+
+                    @GenerateMutableModel
+                    interface NotesState {
+                        val isLoading: Boolean
+                        val notes: List<String>
+                        val error: String?
+                    }
+        """.trimIndent()
+
+        // When
+        val kotlinSource = kotlin(name = "NotesState.kt", contents = source)
+        val result = compile(kotlinSource)
+
+        // Then
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+    }
+
+    @Test
+    fun shouldNotCompile_whenModelHavingMutableFields() {
+        // Given
+        val source = """
+                    package dev.shreyaspatil.mutekt.example
+
+                    import dev.shreyaspatil.mutekt.core.annotations.GenerateMutableModel
+
+                    @GenerateMutableModel
+                    interface NotesState {
+                        var isLoading: Boolean
+                        val notes: List<String>
+                        val error: String?
+                    }
+        """.trimIndent()
+
+        // When
+        val kotlinSource = kotlin(name = "NotesState.kt", contents = source)
+        val result = compile(kotlinSource)
+
+        // Then
+        assert(result.messages.contains("Mutekt is unable to generate state model: NotesState because it promises to be immutable but it has mutable properties: isLoading"))
+    }
+
+    @Test
+    fun shouldNotCompile_whenModelIsNotInterface() {
+        // Given
+        val source = """
+                    package dev.shreyaspatil.mutekt.example
+
+                    import dev.shreyaspatil.mutekt.core.annotations.GenerateMutableModel
+
+                    @GenerateMutableModel
+                    class NotesState {
+                        val isLoading: Boolean = false
+                        val notes: List<String> = emptyList()
+                        val error: String? = null
+                    }
+        """.trimIndent()
+
+        // When
+        val kotlinSource = kotlin(name = "NotesState.kt", contents = source)
+        val result = compile(kotlinSource)
+
+        // Then
+        assert(result.messages.contains("GenerateMutableModel can't be applied to class: must be a `interface` type"))
+    }
+
+    @Test
+    fun shouldNotCompile_whenModelNotHavingPublicVisibility() {
+        // Given
+        val source = """
+                    package dev.shreyaspatil.mutekt.example
+
+                    import dev.shreyaspatil.mutekt.core.annotations.GenerateMutableModel
+
+                    @GenerateMutableModel
+                    internal interface NotesState {
+                        var isLoading: Boolean
+                        val notes: List<String>
+                        val error: String?
+                    }
+        """.trimIndent()
+
+        // When
+        val kotlinSource = kotlin(name = "NotesState.kt", contents = source)
+        val result = compile(kotlinSource)
+
+        // Then
+        assert(result.messages.contains("Mutekt is unable generate mutable model for interface: because interface visibility is not public"))
+    }
+
+    @Test
+    fun shouldNotCompile_whenModelHavingZeroPublicProperties() {
+        // Given
+        val source = """
+                    package dev.shreyaspatil.mutekt.example
+
+                    import dev.shreyaspatil.mutekt.core.annotations.GenerateMutableModel
+
+                    @GenerateMutableModel
+                    interface NotesState {
+                    }
+        """.trimIndent()
+
+        // When
+        val kotlinSource = kotlin(name = "NotesState.kt", contents = source)
+        val result = compile(kotlinSource)
+
+        // Then
+        assert(result.messages.contains("Mutekt will not generate mutable model for NotesState: because there are no public members declared."))
+    }
+
+    private fun prepareCompilation(vararg sourceFiles: SourceFile): KotlinCompilation = KotlinCompilation().apply {
+        workingDir = temporaryFolder.toFile()
+        inheritClassPath = true
+        symbolProcessorProviders = listOf(MutektCodegenProcessorProvider())
+        sources = sourceFiles.asList()
+        verbose = false
+        kspWithCompilation = true
+    }
+
+    private fun compile(vararg sourceFiles: SourceFile): KotlinCompilation.Result =
+        prepareCompilation(*sourceFiles).compile()
+}

--- a/mutekt-core/build.gradle.kts
+++ b/mutekt-core/build.gradle.kts
@@ -10,6 +10,7 @@ repositories {
 dependencies {
     implementation(libs.kotlinx.coroutines.core)
 
+    testImplementation(libs.kotlinx.coroutines.testing)
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)
 }

--- a/mutekt-core/src/main/kotlin/dev/shreyaspatil/mutekt/core/AtomicExecutor.kt
+++ b/mutekt-core/src/main/kotlin/dev/shreyaspatil/mutekt/core/AtomicExecutor.kt
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2022 Shreyas Patil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.shreyaspatil.mutekt.core
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Executor which executes operation atomically.
+ */
+class AtomicExecutor {
+    private val _executing = MutableStateFlow(false)
+    val executing = _executing.asStateFlow()
+
+    /**
+     * Executes the [block] atomically.
+     * If already any operation is executing, it'll wait till its completion.
+     */
+    fun execute(block: () -> Unit) {
+        while (true) {
+            if (_executing.compareAndSet(expect = false, update = true)) {
+                try {
+                    block()
+                } finally {
+                    _executing.update { false }
+                }
+                return
+            }
+        }
+    }
+}

--- a/mutekt-core/src/main/kotlin/dev/shreyaspatil/mutekt/core/MutektState.kt
+++ b/mutekt-core/src/main/kotlin/dev/shreyaspatil/mutekt/core/MutektState.kt
@@ -18,8 +18,23 @@ package dev.shreyaspatil.mutekt.core
 import kotlinx.coroutines.flow.StateFlow
 
 /**
- * Promises that the implementor provides [StateFlow] of type [T]
+ * Represents the state model of type [STATE].
  */
-interface StateFlowable<T> {
-    fun asStateFlow(): StateFlow<T>
+interface MutektState<STATE> {
+    fun asStateFlow(): StateFlow<STATE>
+}
+
+/**
+ * Represents mutable state.
+ *
+ * @property STATE Immutable State model type
+ * @property MUTABLE_STATE Mutable State model type
+ */
+interface MutektMutableState<STATE, MUTABLE_STATE : STATE> : MutektState<STATE> {
+    /**
+     * Updates the [MUTABLE_STATE].
+     *
+     * @param mutate A lambda block which allows to perform mutation on [MUTABLE_STATE].
+     */
+    fun update(mutate: MUTABLE_STATE.() -> Unit)
 }

--- a/mutekt-core/src/test/kotlin/dev/shreyaspatil/mutekt/core/AtomicExecutorTest.kt
+++ b/mutekt-core/src/test/kotlin/dev/shreyaspatil/mutekt/core/AtomicExecutorTest.kt
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2022 Shreyas Patil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.shreyaspatil.mutekt.core
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class AtomicExecutorTest {
+    private lateinit var executor: AtomicExecutor
+
+    @BeforeEach
+    fun setUp() {
+        executor = AtomicExecutor()
+    }
+
+    @Test
+    fun test_execute() = runBlocking {
+        // Given: A sample variable to hold a value
+        var counter = 0
+
+        // When: Multiple jobs to be executed in AtomicExecutor
+        withContext(Dispatchers.Default) { // Executing this in Default dispatcher for parallelism
+            repeat(100) {
+                launch {
+                    repeat(1000) {
+                        executor.execute { counter++ }
+                    }
+                }
+            }
+        }
+
+        // Then: Count should be equal to number of executions
+        assertEquals(100000, counter)
+    }
+
+    @Test
+    fun test_executing() = runBlocking {
+        // Given: A lock for holding execution in executor
+        val mutex = Mutex(locked = true)
+
+        // When: Executor is executing task
+        val job = launch {
+            executor.execute {
+                runBlocking { mutex.lock() }
+            }
+        }
+        // Wait for executor to execute job
+        yield()
+
+        // Then: While task is being executed, state should be true
+        assertTrue(executor.executing.value)
+
+        // Then: On task finish (unlocking lock), state should be false
+        mutex.unlock()
+        job.join()
+        assertFalse(executor.executing.value)
+    }
+}

--- a/mutekt-core/src/test/kotlin/dev/shreyaspatil/mutekt/core/AtomicExecutorTest.kt
+++ b/mutekt-core/src/test/kotlin/dev/shreyaspatil/mutekt/core/AtomicExecutorTest.kt
@@ -56,6 +56,15 @@ class AtomicExecutorTest {
     }
 
     @Test
+    fun test_execute_onError_stateShouldBeUpdated() = runBlocking {
+        // When: Error occurs while executing with AtomicExecutor
+        runCatching { executor.execute { error("") } }
+
+        // Then: The state of `executing` should be reset to false
+        assertFalse(executor.executing.value)
+    }
+
+    @Test
     fun test_executing() = runBlocking {
         // Given: A lock for holding execution in executor
         val mutex = Mutex(locked = true)


### PR DESCRIPTION
# Changelog

- #9:

Added support for updating multiple state fields ***atomically*** with Mutekt-generated mutable model. Just use `update{}` on the instance of mutable model.

Example:
```kt
val state = MutableNotesState(...)

state.update {
  isLoading = false
  notes = listOf("Lorem Ipsum")
}
```